### PR TITLE
Adds a compatibility safeAreaInsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,36 @@ let button = UIButton(type: .Custom)
 button.setBorder(width: 2, color: .redColor())
 ```
 
+## Safe area insets
+
+Taylor provides a backward compatible version of `safeAreaInsets` property for UIView. The original API is available on iOS 11 and above and the replacement fills the gap on older OS version (iOS 7 to 10 inclusively). It is an opt-in feature that requires to be enabled in order to work.
+
+To enable the feature, place this piece of code the earliest possible in your AppDelegate's `application:didFinishLaunching:withOptions` method:
+```swift
+UIViewController.enableCompatibilitySafeAreaInsets()
+```
+
+Your can now access the `compatibilitySafeAreaInsets` property from any UIView. On iOS 11 and above, this property returns `safeAreaInsets`. To receive safe area update callbacks, your view must conform to the `CompatibilitySafeAreaInsetsUpdate` protocol.
+
+To cover every iOS version, your subview could look like this example:
+```swift
+class BaseView: UIView, CompatibilitySafeAreaInsetsUpdate {
+    func compatibilitySafeAreaInsetsDidChange() {
+        commonSafeAreaInsetsDidChange()
+    }
+
+    @available(iOS 11.0, *)
+    override func safeAreaInsetsDidChange() {
+        super.safeAreaInsetsDidChange()
+        commonSafeAreaInsetsDidChange()
+    }
+
+    func commonSafeAreaInsetsDidChange() {
+        setNeedsLayout()
+    }
+}
+```
+
 ## Bonus
 
 * There is a `no-bitcode` branch that's (hopefully) kept up to date with the master.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Taylor
 
-iOS Framework with a bunch of classes and helpers for Swift. 
+iOS Framework with a bunch of classes and helpers for Swift.
 
 ## Requirements
 
@@ -50,7 +50,7 @@ UIViewController.enableCompatibilitySafeAreaInsets()
 
 Your can now access the `compatibilitySafeAreaInsets` property from any UIView. On iOS 11 and above, this property returns `safeAreaInsets`. To receive safe area update callbacks, your view must conform to the `CompatibilitySafeAreaInsetsUpdate` protocol.
 
-To cover every iOS version, your subview could look like this example:
+To cover every iOS versions, your subview could look like this:
 ```swift
 class BaseView: UIView, CompatibilitySafeAreaInsetsUpdate {
     func compatibilitySafeAreaInsetsDidChange() {

--- a/Taylor.xcodeproj/project.pbxproj
+++ b/Taylor.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		C82DD1D81FE414B0002C3942 /* CGPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82DD1D71FE414B0002C3942 /* CGPoint.swift */; };
 		C82DD1DA1FE41FB1002C3942 /* UIViewControllerContainer+StatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82DD1D91FE41FB1002C3942 /* UIViewControllerContainer+StatusBar.swift */; };
 		C82DD1DC1FE42012002C3942 /* UIControl+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82DD1DB1FE42012002C3942 /* UIControl+Actions.swift */; };
+		C8E5946B1FF515D4000C184D /* UIView+SafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E5946A1FF515D4000C184D /* UIView+SafeArea.swift */; };
+		C8E5946D1FF5183E000C184D /* UIViewSafeAreaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E5946C1FF5183E000C184D /* UIViewSafeAreaTests.swift */; };
 		DF42A5A81D3EB07A00C2FE9B /* NSDateTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF42A5A71D3EB07A00C2FE9B /* NSDateTest.swift */; };
 		DF45FE9D1CCFD1F90033F071 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF45FE9C1CCFD1F90033F071 /* String.swift */; };
 		DF9AE4C71DD0C1EE0061B155 /* CGFloatText.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9AE4C61DD0C1EE0061B155 /* CGFloatText.swift */; };
@@ -61,6 +63,8 @@
 		C82DD1D71FE414B0002C3942 /* CGPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGPoint.swift; sourceTree = "<group>"; };
 		C82DD1D91FE41FB1002C3942 /* UIViewControllerContainer+StatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewControllerContainer+StatusBar.swift"; sourceTree = "<group>"; };
 		C82DD1DB1FE42012002C3942 /* UIControl+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+Actions.swift"; sourceTree = "<group>"; };
+		C8E5946A1FF515D4000C184D /* UIView+SafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SafeArea.swift"; sourceTree = "<group>"; };
+		C8E5946C1FF5183E000C184D /* UIViewSafeAreaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewSafeAreaTests.swift; sourceTree = "<group>"; };
 		DF42A5A71D3EB07A00C2FE9B /* NSDateTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDateTest.swift; sourceTree = "<group>"; };
 		DF45FE9C1CCFD1F90033F071 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		DF9AE4C61DD0C1EE0061B155 /* CGFloatText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CGFloatText.swift; path = Types/CGFloatText.swift; sourceTree = "<group>"; };
@@ -143,6 +147,7 @@
 				DF9F948C1CE360520008487F /* UIButtonTest.swift */,
 				DF42A5A71D3EB07A00C2FE9B /* NSDateTest.swift */,
 				7A3FC2B21CAC2B0B007A4063 /* UIEdgeInsetsTests.swift */,
+				C8E5946C1FF5183E000C184D /* UIViewSafeAreaTests.swift */,
 			);
 			path = TaylorTests;
 			sourceTree = "<group>";
@@ -173,6 +178,7 @@
 				DFBFDA421CAF0B0900623836 /* UIView.swift */,
 				C82DD1D91FE41FB1002C3942 /* UIViewControllerContainer+StatusBar.swift */,
 				C82DD1DB1FE42012002C3942 /* UIControl+Actions.swift */,
+				C8E5946A1FF515D4000C184D /* UIView+SafeArea.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -334,6 +340,7 @@
 				DFBC07B91CAC399700A7A665 /* UIScreen.swift in Sources */,
 				DF45FE9D1CCFD1F90033F071 /* String.swift in Sources */,
 				DFBFDA431CAF0B0900623836 /* UIView.swift in Sources */,
+				C8E5946B1FF515D4000C184D /* UIView+SafeArea.swift in Sources */,
 				DFBC07B51CAC399700A7A665 /* UIColor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -346,6 +353,7 @@
 				DF9F948D1CE360520008487F /* UIButtonTest.swift in Sources */,
 				DF9AE4C71DD0C1EE0061B155 /* CGFloatText.swift in Sources */,
 				7ACD098F1CC04264000FAAA0 /* ExtendedButtonTests.swift in Sources */,
+				C8E5946D1FF5183E000C184D /* UIViewSafeAreaTests.swift in Sources */,
 				7A3FC2B31CAC2B0B007A4063 /* UIEdgeInsetsTests.swift in Sources */,
 				DF42A5A81D3EB07A00C2FE9B /* NSDateTest.swift in Sources */,
 			);

--- a/Taylor/UI/UIView+SafeArea.swift
+++ b/Taylor/UI/UIView+SafeArea.swift
@@ -55,19 +55,16 @@ extension UIView {
             }
         }
         set {
+            let didChange: Bool = compatibilitySafeAreaInsets != newValue
             objc_setAssociatedObject(self, &AssociatedKeys.compatibilitySafeAreaInsets, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            if didChange, let updatable = self as? CompatibilitySafeAreaInsetsUpdate {
+                updatable.compatibilitySafeAreaInsetsDidChange()
+            }
         }
     }
 
     fileprivate func assignSafeAreaInsetsRecursively(insets: UIEdgeInsets) {
-        let didChange: Bool = compatibilitySafeAreaInsets != insets
         compatibilitySafeAreaInsets = insets
-        if didChange {
-            if let updatable = self as? CompatibilitySafeAreaInsetsUpdate {
-                updatable.compatibilitySafeAreaInsetsDidChange()
-            }
-        }
-
         for subview in subviews {
             let topSafeInsetValue = max(insets.top - subview.frame.origin.y, 0)
             let leftSafeInsetValue = max(insets.left - subview.frame.origin.x, 0)

--- a/Taylor/UI/UIView+SafeArea.swift
+++ b/Taylor/UI/UIView+SafeArea.swift
@@ -1,0 +1,89 @@
+//
+//  UIView+SafeArea.swift
+//  Taylor
+//
+//  Created by Antoine Lamy on 2017-12-28.
+//  Copyright © 2017 Mirego. All rights reserved.
+//
+
+import UIKit
+import ObjectiveC
+
+@available(iOS 7.0, *)
+public protocol IgnoreNewerSafeAreaInsets {}
+
+@available(iOS 7.0, *)
+public protocol CompatibilitySafeAreaInsetsUpdate {
+    func compatibilitySafeAreaInsetsDidChange()
+}
+
+public extension UIViewController {
+    @available(iOS 7.0, *)
+    class func enableCompatibilitySafeAreaInsets() {
+        guard self === UIViewController.self else { return }
+        swizzleMethod(self, #selector(UIViewController.viewWillLayoutSubviews), #selector(UIViewController.swizzled_viewWillLayoutSubviews))
+    }
+
+    @objc private func swizzled_viewWillLayoutSubviews() {
+        self.swizzled_viewWillLayoutSubviews()
+        if #available(iOS 11.0, *), !(self is IgnoreNewerSafeAreaInsets) {
+            // Do nothing, let the iOS 11+ safeAreaInsets mecanism do his thing
+        } else {
+            let safeAreaInsets: UIEdgeInsets
+            if #available(iOS 11.0, *) {
+                safeAreaInsets = UIEdgeInsets(top: topLayoutGuide.length, left: additionalSafeAreaInsets.left, bottom: bottomLayoutGuide.length, right: additionalSafeAreaInsets.right)
+            } else {
+                safeAreaInsets = UIEdgeInsets(top: topLayoutGuide.length, left: 0, bottom: bottomLayoutGuide.length, right: 0)
+            }
+            view.assignSafeAreaInsetsRecursively(insets: safeAreaInsets)
+        }
+    }
+}
+
+extension UIView {
+    private struct AssociatedKeys {
+        static var compatibilitySafeAreaInsets = UnsafeMutablePointer<Int8>.allocate(capacity: 1)
+    }
+
+    @available(iOS 7.0, *)
+    public private(set) var compatibilitySafeAreaInsets: UIEdgeInsets {
+        get {
+            if #available(iOS 11.0, *), !(self is IgnoreNewerSafeAreaInsets) {
+                return safeAreaInsets
+            } else {
+                return objc_getAssociatedObject(self, &AssociatedKeys.compatibilitySafeAreaInsets) as? UIEdgeInsets ?? UIEdgeInsets.zero
+            }
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.compatibilitySafeAreaInsets, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    fileprivate func assignSafeAreaInsetsRecursively(insets: UIEdgeInsets) {
+        let didChange: Bool = compatibilitySafeAreaInsets != insets
+        compatibilitySafeAreaInsets = insets
+        if didChange {
+            if let updatable = self as? CompatibilitySafeAreaInsetsUpdate {
+                updatable.compatibilitySafeAreaInsetsDidChange()
+            }
+        }
+
+        for subview in subviews {
+            let topSafeInsetValue = max(insets.top - subview.frame.origin.y, 0)
+            let leftSafeInsetValue = max(insets.left - subview.frame.origin.x, 0)
+            let bottomSafeInsetValue = max((subview.frame.origin.y + subview.frame.size.height) - bounds.size.height - insets.bottom, 0)
+            let rightSafeInsetValue = max((subview.frame.origin.x + subview.frame.size.width) - bounds.size.width - insets.right, 0)
+            let subviewSafeAreaInsets = UIEdgeInsets(top: topSafeInsetValue, left: leftSafeInsetValue, bottom: bottomSafeInsetValue, right: rightSafeInsetValue)
+            if subviewSafeAreaInsets != UIEdgeInsets.zero {
+                subview.assignSafeAreaInsetsRecursively(insets: subviewSafeAreaInsets)
+            }
+        }
+    }
+}
+
+private let swizzleMethod: (AnyClass, Selector, Selector) -> () = { forClass, originalSelector, swizzledSelector in
+    if let originalMethod = class_getInstanceMethod(forClass, originalSelector),
+        let swizzledMethod = class_getInstanceMethod(forClass, swizzledSelector) {
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+}

--- a/TaylorTests/UIViewSafeAreaTests.swift
+++ b/TaylorTests/UIViewSafeAreaTests.swift
@@ -1,0 +1,126 @@
+//
+//  UIViewSafeAreaTests.swift
+//  TaylorTests
+//
+//  Created by Antoine Lamy on 2017-12-28.
+//  Copyright © 2017 Mirego. All rights reserved.
+//
+
+import XCTest
+import Taylor
+
+class UIViewSafeAreaTests: XCTestCase {
+    private var viewController: TestViewController!
+    private var navigationController: UINavigationController!
+    private var window: UIWindow!
+
+    override class func setUp() {
+        super.setUp()
+        UIViewController.enableCompatibilitySafeAreaInsets()
+    }
+    
+    override func setUp() {
+        super.setUp()
+        viewController = TestViewController()
+        navigationController = UINavigationController(rootViewController: viewController)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        viewController = nil
+        navigationController = nil
+        window = nil
+    }
+
+    private func setupWindow(with viewController: UIViewController) {
+        window = UIWindow()
+        window.rootViewController = viewController
+        window.addSubview(viewController.view)
+
+        // Testing UIViewController's layout methods is kind of bad
+        // but needed in our case so we need to wait some time
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+    }
+
+    func testOpaqueNavigationBar() {
+        navigationController.navigationBar.barStyle = .blackOpaque
+        navigationController.navigationBar.isTranslucent = false
+        setupWindow(with: navigationController)
+
+        let expectedSafeAreaInsets = UIEdgeInsets.zero
+        let expectedOffsetViewSafeAreaInsets = UIEdgeInsets.zero
+        if #available(iOS 11.0, *) {
+            XCTAssertEqual(viewController.view.safeAreaInsets, expectedSafeAreaInsets)
+            XCTAssertEqual(viewController.mainView.offsetView.safeAreaInsets, expectedOffsetViewSafeAreaInsets)
+            XCTAssertFalse(viewController.mainView.safeAreaInsetsDidChangeCalled)
+        }
+        XCTAssertEqual(viewController.mainView.compatibilitySafeAreaInsets, expectedSafeAreaInsets)
+        XCTAssertEqual(viewController.mainView.offsetView.compatibilitySafeAreaInsets, expectedOffsetViewSafeAreaInsets)
+        XCTAssertFalse(viewController.mainView.compatibilitySafeAreaInsetsDidChangeCalled)
+    }
+
+    func testTranslucentNavigationBar() {
+        let expectedSafeAreaInsets: UIEdgeInsets
+        let expectedOffsetViewSafeAreaInsets: UIEdgeInsets
+        if #available(iOS 11.0, *) {
+            viewController.additionalSafeAreaInsets = UIEdgeInsets(top: 10, left: 10, bottom: 30, right: 0)
+            expectedSafeAreaInsets = UIEdgeInsets(top: 54, left: 10, bottom: 30, right: 0)
+            expectedOffsetViewSafeAreaInsets = UIEdgeInsets(top: 44, left: 10, bottom: 0, right: 0)
+        } else {
+            expectedSafeAreaInsets = UIEdgeInsets(top: 44, left: 0, bottom: 0, right: 0)
+            expectedOffsetViewSafeAreaInsets = UIEdgeInsets(top: 34, left: 0, bottom: 0, right: 0)
+        }
+        navigationController.navigationBar.barStyle = .blackTranslucent
+        setupWindow(with: navigationController)
+
+
+        if #available(iOS 11.0, *) {
+            XCTAssertEqual(viewController.view.safeAreaInsets, expectedSafeAreaInsets)
+            XCTAssertEqual(viewController.mainView.offsetView.safeAreaInsets, expectedOffsetViewSafeAreaInsets)
+            XCTAssertTrue(viewController.mainView.safeAreaInsetsDidChangeCalled)
+        }
+        XCTAssertEqual(viewController.mainView.compatibilitySafeAreaInsets, expectedSafeAreaInsets)
+        XCTAssertEqual(viewController.mainView.offsetView.compatibilitySafeAreaInsets, expectedOffsetViewSafeAreaInsets)
+        XCTAssertTrue(viewController.mainView.compatibilitySafeAreaInsetsDidChangeCalled)
+    }
+}
+
+fileprivate class TestViewController: UIViewController, IgnoreNewerSafeAreaInsets {
+    var mainView: TestView { return self.view as! TestView }
+    override func loadView() {
+        self.view = TestView()
+    }
+}
+
+fileprivate class TestView: UIView, CompatibilitySafeAreaInsetsUpdate, IgnoreNewerSafeAreaInsets {
+    let offsetView = UIView()
+    var safeAreaInsetsDidChangeCalled: Bool = false
+    var compatibilitySafeAreaInsetsDidChangeCalled: Bool = false
+
+    init() {
+        super.init(frame: CGRect.zero)
+        backgroundColor = UIColor.red
+
+        offsetView.backgroundColor = UIColor.green
+        addSubview(offsetView)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        offsetView.frame = CGRect(x: 0, y: 10, width: bounds.width, height: 100)
+    }
+
+    func compatibilitySafeAreaInsetsDidChange() {
+        compatibilitySafeAreaInsetsDidChangeCalled = true
+    }
+
+    @available(iOS 11.0, *)
+    override func safeAreaInsetsDidChange() {
+        super.safeAreaInsetsDidChange()
+        safeAreaInsetsDidChangeCalled = true
+    }
+}


### PR DESCRIPTION
Provides a backward compatible version of `safeAreaInsets` property for UIView. The original API is available on iOS 11 and above and the replacement fills the gap on older OS version (iOS 7 to 10 inclusively).