### PR TITLE
Fix Apple Non-public api validation error: imageForKey:, performActionWithSender:, setImage:forKey:

### DIFF
--- a/Taylor/UI/UIControl+Actions.swift
+++ b/Taylor/UI/UIControl+Actions.swift
@@ -34,7 +34,7 @@ private class ActionTrampoline<T>: NSObject {
         self.action = action
     }
 
-    @objc func performAction(sender: UIControl) {
+    @objc func exectuteControlAction(sender: UIControl) {
         action(sender as! T)
     }
 }
@@ -47,7 +47,7 @@ extension UIControl: UIControlActionFunctionProtocol {}
 public extension UIControlActionFunctionProtocol where Self: UIControl {
     public func addAction(events: UIControl.Event, _ action: @escaping (Self)  -> Void) {
         let trampoline = ActionTrampoline(action: action)
-        addTarget(trampoline, action: #selector(trampoline.performAction(sender:)), for: events)
+        addTarget(trampoline, action: #selector(trampoline.exectuteControlAction(sender:)), for: events)
         objc_setAssociatedObject(self, actionKey(forEvents: events), trampoline, .OBJC_ASSOCIATION_RETAIN)
     }
 


### PR DESCRIPTION
On avait déjà fixé ScratchViewModel pour ça. Ce nom de méthode confuse Apple et il peut rejecter ton app pour ça 🤷‍♂️