### PR TITLE
Fix SPM build: import UIKit in UIButton/UIDevice/UIEdgeInsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ github "mirego/taylor-ios"
 Add the following dependency to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/mirego/taylor-ios.git", from: "1.7.0")
+.package(url: "https://github.com/mirego/taylor-ios.git", from: "1.7.1")
 ```
 
 Or add it via Xcode: **File › Add Package Dependencies…** and enter the repository URL.

--- a/Sources/Taylor/UI/UIButton.swift
+++ b/Sources/Taylor/UI/UIButton.swift
@@ -25,7 +25,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import Foundation
+import UIKit
 
 extension UIButton
 {

--- a/Sources/Taylor/UI/UIDevice.swift
+++ b/Sources/Taylor/UI/UIDevice.swift
@@ -25,7 +25,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import Foundation
+import UIKit
 
 public extension UIDevice
 {

--- a/Sources/Taylor/UI/UIEdgeInsets.swift
+++ b/Sources/Taylor/UI/UIEdgeInsets.swift
@@ -25,7 +25,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import Foundation
+import UIKit
 
 public extension UIEdgeInsets
 {


### PR DESCRIPTION
## 📖 Description
`UIButton.swift`, `UIDevice.swift` and `UIEdgeInsets.swift` only `import Foundation`. Under CocoaPods they compiled because the Xcode project's prefix header (`.pch`) implicitly imported UIKit — but **SPM has no prefix header**, so consuming the package via SPM fails:

```
error: cannot find type 'UIButton' in scope
error: cannot find type 'UIDevice' in scope
error: cannot find type 'UIEdgeInsets' in scope
```

## 👷 Fix
Replace `import Foundation` with `import UIKit` (which re-exports Foundation) in the three files, matching the other UI extensions (e.g. `UIView.swift`).

## ✅ Verification
Building the package for the iOS Simulator now succeeds (previously failed on these 3 files). Surfaced while adopting `taylor-ios` 1.7.0 via SPM in another project.

## ⏭️ Follow-up
Tag a **1.7.1** release so SPM consumers can pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)